### PR TITLE
added uniform boosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,6 @@ Listing of useful (mostly) public learning resources for machine learning applic
 - G. Louppe, M. Kagan, and K. Cranmer, "[Learning to Pivot with Adversarial Networks](https://inspirehep.net/record/1495901)," arXiv:1611.01046 [stat.ME]. (November 3, 2016)
     - Lecture: [(Machine) Learning to Pivot with Adversarial Networks](http://indico.iihe.ac.be/indico/conferenceDisplay.py?confId=1082), by [Gilles Louppe](https://glouppe.github.io/)
 
-- J. Stevens, M. Williams, "[uBoost: A boosting method for producing uniform selection efficiencies from multivariate classifiers](https://inspirehep.net/record/1236355)," arXiv:1305.7248 [nucl-ex]. (May 30, 2013)
-
-- A. Rogozhnikov, A. Bukva, V. Gligorov, A. Ustyuzhanin, M. Williams, "[New approaches for boosting to uniformity](https://inspirehep.net/record/1322385)," arXiv:1410.4140 [hep-ex]. (October 15, 2014)
-
 - J. Barnard, E. N. Dawe, M. J. Dolan, and N. Rajcic, ["Parton Shower Uncertainties in Jet Substructure Analyses with Deep Neural Networks](https://inspirehep.net/record/1485081)," Phys. Rev. D95 (2017) no. 1, 014018, arXiv:1609.00607 [hep-ph] (September 2, 2016)
 
 - S. Caron, J.S. Kim, K. Rolbiecki, R. Ruiz de Austri, B. Stienen "[The BSM-AI project: SUSY-AI -- Generalizing LHC limits on supersymmetry with machine learning](https://inspirehep.net/record/1456927)", EPJ C (2017) 77:257, arXiv:1605.02797 [hep-ph]. (May 9, 2016)
@@ -137,7 +133,11 @@ Listing of useful (mostly) public learning resources for machine learning applic
 
 - L. de Oliveira, M. Kagan, L. Mackey, B. Nachman, and A. Schwartzman, "[Jet-images deep learning edition](https://inspirehep.net/record/1405106)," JHEP 07 (2016) 069, arXiv:1511.05190 [hep-ph]. (November 16, 2015)
 
+- A. Rogozhnikov, A. Bukva, V. Gligorov, A. Ustyuzhanin, M. Williams, "[New approaches for boosting to uniformity](https://inspirehep.net/record/1322385)," arXiv:1410.4140 [hep-ex]. (October 15, 2014)
+
 - P. Baldi, P. Sadowski, and D. Whiteson, ["Searching for Exotic Particles in High-Energy Physics with Deep Learning](https://inspirehep.net/record/1281836)," Nature Commun. 5 (2014) 4308, arXiv:1402.4735 [hep-ph]. (February 19, 2014)
+
+- J. Stevens, M. Williams, "[uBoost: A boosting method for producing uniform selection efficiencies from multivariate classifiers](https://inspirehep.net/record/1236355)," arXiv:1305.7248 [nucl-ex]. (May 30, 2013)
 
 ## Workshops
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ Listing of useful (mostly) public learning resources for machine learning applic
 - G. Louppe, M. Kagan, and K. Cranmer, "[Learning to Pivot with Adversarial Networks](https://inspirehep.net/record/1495901)," arXiv:1611.01046 [stat.ME]. (November 3, 2016)
     - Lecture: [(Machine) Learning to Pivot with Adversarial Networks](http://indico.iihe.ac.be/indico/conferenceDisplay.py?confId=1082), by [Gilles Louppe](https://glouppe.github.io/)
 
+- J. Stevens, M. Williams, "[uBoost: A boosting method for producing uniform selection efficiencies from multivariate classifiers](https://inspirehep.net/record/1236355)," arXiv:1305.7248 [nucl-ex]. (May 30, 2013)
+
+- A. Rogozhnikov, A. Bukva, V. Gligorov, A. Ustyuzhanin, M. Williams, "[New approaches for boosting to uniformity](https://inspirehep.net/record/1322385)," arXiv:1410.4140 [hep-ex]. (October 15, 2014)
+
 - J. Barnard, E. N. Dawe, M. J. Dolan, and N. Rajcic, ["Parton Shower Uncertainties in Jet Substructure Analyses with Deep Neural Networks](https://inspirehep.net/record/1485081)," Phys. Rev. D95 (2017) no. 1, 014018, arXiv:1609.00607 [hep-ph] (September 2, 2016)
 
 - S. Caron, J.S. Kim, K. Rolbiecki, R. Ruiz de Austri, B. Stienen "[The BSM-AI project: SUSY-AI -- Generalizing LHC limits on supersymmetry with machine learning](https://inspirehep.net/record/1456927)", EPJ C (2017) 77:257, arXiv:1605.02797 [hep-ph]. (May 9, 2016)

--- a/tex/HEPML.bib
+++ b/tex/HEPML.bib
@@ -187,3 +187,37 @@
  archivePrefix  = "arXiv",
  primaryClass   = "hep-ph",
 }
+
+%May 30, 2013
+@article{Stevens:2013dya,
+ author         = "Stevens, Justin and Williams, Mike",
+ title          = "{uBoost: A boosting method for producing uniform
+                   selection efficiencies from multivariate classifiers}",
+ journal        = "JINST",
+ volume         = "8",
+ year           = "2013",
+ pages          = "P12013",
+ doi            = "10.1088/1748-0221/8/12/P12013",
+ eprint         = "1305.7248",
+ archivePrefix  = "arXiv",
+ primaryClass   = "nucl-ex",
+ SLACcitation   = "%%CITATION = ARXIV:1305.7248;%%"
+}
+
+%October 15, 2014
+@article{Rogozhnikov:2014zea,
+ author         = "Rogozhnikov, Alex and Bukva, Aleksandar and Gligorov, V.
+                   V. and Ustyuzhanin, Andrey and Williams, Mike",
+ title          = "{New approaches for boosting to uniformity}",
+ journal        = "JINST",
+ volume         = "10",
+ year           = "2015",
+ number         = "03",
+ pages          = "T03002",
+ doi            = "10.1088/1748-0221/10/03/T03002",
+ eprint         = "1410.4140",
+ archivePrefix  = "arXiv",
+ primaryClass   = "hep-ex",
+ SLACcitation   = "%%CITATION = ARXIV:1410.4140;%%"
+}
+

--- a/tex/HEPML.tex
+++ b/tex/HEPML.tex
@@ -24,6 +24,8 @@
  \item~\cite{Paganini:2017hrr}
  \item~\cite{Shimmin:2017mfk}
  \item~\cite{Louppe:2017ipp}
+ \item~\cite{Rogozhnikov:2014zea}
+ \item~\cite{Stevens:2013dya}
  \item~\cite{deOliveira:2017pjk}
  \item~\cite{Komiske:2016rsd}
  \item~\cite{Acciarri:2016ryt}

--- a/tex/HEPML.tex
+++ b/tex/HEPML.tex
@@ -24,8 +24,6 @@
  \item~\cite{Paganini:2017hrr}
  \item~\cite{Shimmin:2017mfk}
  \item~\cite{Louppe:2017ipp}
- \item~\cite{Rogozhnikov:2014zea}
- \item~\cite{Stevens:2013dya}
  \item~\cite{deOliveira:2017pjk}
  \item~\cite{Komiske:2016rsd}
  \item~\cite{Acciarri:2016ryt}
@@ -35,7 +33,9 @@
  \item~\cite{Barnard:2016qma}
  \item~\cite{Aurisano:2016jvx}
  \item~\cite{deOliveira:2015xxd}
+ \item~\cite{Rogozhnikov:2014zea}
  \item~\cite{Baldi:2014kfa}
+ \item~\cite{Stevens:2013dya}
 \end{itemize}
 
 \clearpage


### PR DESCRIPTION
Hi,

I added the uniform boosting methods in the list right after the pivoting with adversarial (Louppe et al) since it addresses the same use case.

Cheers,
Paul