### PR TITLE
adding hep_ml package

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Listing of useful (mostly) public learning resources for machine learning applic
 
 - [ttree2hdf5](https://github.com/dguest/ttree2hdf5): Mimimalist ROOT to HDF5 converter
 
+- [hepml](https://github.com/arogozhnikov/hep_ml): Python algorithms and tools for HEP ML use cases
+
 <!-- ## Notebooks - [Vince Croft RooFit Notebooks](https://www.nikhef.nl/~vcroft/notebooks.html) -->
 
  ## Papers


### PR DESCRIPTION
Quickly checking, hep_ml has more stars than lwtnn and not much less than root_numpy. So definitively a common software, I'm not sure if it makes more sense under the "bridge" tools.