### PR TITLE
Add Deep Learning for Physical Sciences Papers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ Listing of useful (mostly) public learning resources for machine learning applic
 
 > A `.bib` file for all papers listed is [available in the `tex` directory](https://github.com/iml-wg/HEP-ML-Resources/blob/master/tex/HEPML.bib).
 
+- V. Estrade, C. Germain, I. Guyon and D. Rousseau, [Adversarial learning to eliminate systematic errors: a case study in High Energy Physics](https://dl4physicalsciences.github.io/files/nips_dlps_2017_1.pdf), Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017). (December 8, 2017)
+
+- D. Weitekamp III, T. Nguyen, D. Anderson, R. Castello, M.Pierini, M. Spiropulu and J. Vlimant, [Deep topology classifiers for a more efficient trigger selection at the LHC](https://dl4physicalsciences.github.io/files/nips_dlps_2017_3.pdf), Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017). (December 8, 2017)
+
+- L. Hertel, L. Li, P. Baldi and J. Bian, [Convolutional Neural Networks for Electron Neutrino and Electron Shower Energy Reconstruction in the NOvA Detectors](https://dl4physicalsciences.github.io/files/nips_dlps_2017_7.pdf), Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017). (December 8, 2017)
+
+- M. Stoye, J. Kieseler, M. Verzetti, H. Qu, L. Gouskos, A. Stakia and the CMS Collaboration, [DeepJet: Generic physics object based jet multiclass classification for LHC experiments](https://dl4physicalsciences.github.io/files/nips_dlps_2017_10.pdf), Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017). (December 8, 2017)
+
+- B. Hooberman, A. Farbin, G. Khattak, V. Pacela, M. Pierini, J. Vlimant, M. Spiropulu, W. Wei, M. Zhang and S. Vallecorsa, [Calorimetry with Deep Learning: Particle Classification, Energy Regression, and Simulation for High-Energy Physics](https://dl4physicalsciences.github.io/files/nips_dlps_2017_15.pdf), Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017). (December 8, 2017)
+
+- M. Paganini, L. de Oliveira and B. Nachman, [Survey of Machine Learning Techniques for High Energy Electromagnetic Shower Classification](https://dl4physicalsciences.github.io/files/nips_dlps_2017_24.pdf), Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017). (December 8, 2017)
+
+- L. de Oliveira, M. Paganini, and B. Nachman, [Tips and Tricks for Training GANs with Physics Constraints](https://dl4physicalsciences.github.io/files/nips_dlps_2017_26.pdf), Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017). (December 8, 2017)
+
+- S. Farrell, P. Calafiura, M. Mudigonda, Prabhat, D. Anderson, J. Bendavid, M. Spiropoulou, J. Vlimant, S. Zheng, G. Cerati, L. Gray, J. Kowalkowski, P. Spentzouris, A. Tsaris and D. Zurawski, [Particle Track Reconstruction with Deep Learning](https://dl4physicalsciences.github.io/files/nips_dlps_2017_28.pdf), Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017). (December 8, 2017)
+
+- I. Henrion, K. Cranmer, J. Bruna, K. Cho, J. Brehmer, G. Louppe and G. Rochette, [Neural Message Passing for Jet Physics](https://dl4physicalsciences.github.io/files/nips_dlps_2017_29.pdf), Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017). (December 8, 2017)
+
 - T. Cheng, "[Recursive Neural Networks in Quark/Gluon Tagging](https://inspirehep.net/record/1634876)," arXiv:1711.02633 [hep-ph]. (November 7, 2017)
 
 - M. Frate, K. Cranmer, S. Kalia, A. Vandenberg-Rodes, and D. Whiteson, “[Modeling Smooth Backgrounds and Generic Localized Signals with Gaussian Processes](https://inspirehep.net/record/1624168),” arXiv:1709.05681 [physics.data-an]. (September 17, 2017)

--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ Listing of useful (mostly) public learning resources for machine learning applic
 
 > A `.bib` file for all papers listed is [available in the `tex` directory](https://github.com/iml-wg/HEP-ML-Resources/blob/master/tex/HEPML.bib).
 
- - M. Frate, K. Cranmer, S. Kalia, A. Vandenberg-Rodes, and D. Whiteson, “[Modeling Smooth Backgrounds and Generic Localized Signals with Gaussian Processes](https://inspirehep.net/record/1624168),” arXiv:1709.05681 [physics.data-an]. (September 17, 2017)
+- T. Cheng, "[Recursive Neural Networks in Quark/Gluon Tagging](https://inspirehep.net/record/1634876)," arXiv:1711.02633 [hep-ph]. (November 7, 2017)
 
- - E. M. Metodiev, B. Nachman, and J. Thaler, “[Classification without labels: Learning
+- M. Frate, K. Cranmer, S. Kalia, A. Vandenberg-Rodes, and D. Whiteson, “[Modeling Smooth Backgrounds and Generic Localized Signals with Gaussian Processes](https://inspirehep.net/record/1624168),” arXiv:1709.05681 [physics.data-an]. (September 17, 2017)
+
+- E. M. Metodiev, B. Nachman, and J. Thaler, “[Classification without labels: Learning
 from mixed samples in high energy physics](https://inspirehep.net/record/1615464),” arXiv:1708.02949 [hep-ph]. (August 9, 2017)
 
 - J. Bendavid, "[Efficient Monte Carlo Integration Using Boosted Decision Trees and Generative Deep Neural Networks](https://inspirehep.net/record/1608392)," arXiv:1707.00028 [hep-ph]. (June 30, 2017)

--- a/README.md
+++ b/README.md
@@ -201,12 +201,12 @@ from mixed samples in high energy physics](https://inspirehep.net/record/1615464
 
 ### Upcoming
 
-- [Deep Learning for Physical Sciences at NIPS](https://dl4physicalsciences.github.io/) (December 8, 2017)
-
 - [4th International Connecting The Dots Workshop (2018)](https://indico.cern.ch/event/658267/) (March 20-22, 2018)
 
 ### Past
 
+- [Machine Learning for Jet Physics](https://indico.physics.lbl.gov/indico/event/546/) (December 11-13, 2017)
+- [Deep Learning for Physical Sciences at NIPS](https://dl4physicalsciences.github.io/) (December 8, 2017)
 - [18th International Workshop on Advanced Computing and Analysis Techniques in Physics Research (ACAT 2017)](https://indico.cern.ch/event/567550/) (August 21-25, 2017)
 - [Hammers & Nails - Machine Learning & HEP](https://www.weizmann.ac.il/conferences/SRitp/Summer2017/) (July 19-28, 2017)
 - [CMS Machine Learning Workshop (2017)](https://indico.cern.ch/event/646801) (July 5-6, 2017) ![CMS only](https://img.shields.io/badge/restricted-CMS-red.svg)

--- a/tex/HEPML.bib
+++ b/tex/HEPML.bib
@@ -1,5 +1,100 @@
 # HEPML Papers
 
+% December 8, 2017
+@conference{Estrade:DLPS2017,
+ author         = "Victor Estrade and Cecile Germain and Isabelle Guyon and David Rousseau",
+ title          = "{Adversarial learning to eliminate systematic errors: a case study
+ in High Energy Physics}",
+ booktitle      = "{Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017)}",
+ year           = "2017",
+ url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_1.pdf}"
+}
+
+% December 8, 2017
+@conference{Weitekamp:DLPS2017,
+ author         = "Daniel Weitekamp III and Thong Q. Nguyen and Dustin Anderson and
+ Roberto Castello and Maurizio Pierini and Maria Spiropulu and Jean-Roch Vlimant",
+ title          = "{Deep topology classifiers for a more efficient trigger selection at the LHC}",
+ booktitle      = "{Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017)}",
+ year           = "2017",
+ url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_3.pdf}"
+}
+
+% December 8, 2017
+@conference{Hertel:DLPS2017,
+ author         = "Lars Hertel and Lingge Li and Pierre Baldi and Jianming Bian",
+ title          = "{Convolutional Neural Networks for Electron Neutrino and Electron
+  Shower Energy Reconstruction in the NO$\nu$A Detectors}",
+ booktitle      = "{Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017)}",
+ year           = "2017",
+ url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_7.pdf}"
+}
+
+% December 8, 2017
+@conference{Stoye:DLPS2017,
+ author         = "Markus Stoye and Jan Kieseler and Mauro Verzetti and Huilin Qu and
+ Loukas Gouskos and Anna Stakia and {CMS Collaboration}",
+ title          = "{DeepJet: Generic physics object based jet multiclass classification
+ for LHC experiments}",
+ booktitle      = "{Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017)}",
+ year           = "2017",
+ url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_10.pdf}"
+}
+
+% December 8, 2017
+@conference{Hooberman:DLPS2017,
+ author         = "Benjamin Hooberman and Amir Farbin and Gulrukh Khattak and Vit{\'o}ria Pacela
+ and Maurizio Pierini and Jean-Roch Vlimant and Maria Spiropulu and Wei Wei and Matt Zhang
+ and Sofia Vallecorsa",
+ title          = "{Calorimetry with Deep Learning: Particle Classification, Energy Regression,
+ and Simulation for High-Energy Physics}",
+ booktitle      = "{Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017)}",
+ year           = "2017",
+ url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_15.pdf}"
+}
+
+% December 8, 2017
+@conference{Paganini:DLPS2017,
+ author         = "Paganini, Michela and de Oliveira, Luke and Nachman,
+ Benjamin",
+ title          = "{Survey of Machine Learning Techniques for High Energy
+ Electromagnetic Shower Classification}",
+ booktitle      = "{Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017)}",
+ year           = "2017",
+ url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_24.pdf}"
+}
+
+% December 8, 2017
+@conference{Oliveira:DLPS2017,
+ author         = "de Oliveira, Luke and Paganini, Michela and Nachman, Benjamin",
+ title          = "{Tips and Tricks for Training GANs with Physics Constraints}",
+ booktitle      = "{Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017)}",
+ year           = "2017",
+ url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_26.pdf}"
+}
+
+% December 8, 2017
+@conference{Farrell:DLPS2017,
+ author         = "Steven Farrell and Paolo Calafiura and Mayur Mudigonda and Prabhat
+ and Dustin Anderson and Josh Bendavid and Maria Spiropoulou and Jean-Roch Vlimant
+ and Stephan Zheng and Giuseppe Cerati and Lindsey Gray and Jim Kowalkowski
+ and Panagiotis Spentzouris and Aristeidis Tsaris and Daniel Zurawski",
+ title          = "{Particle Track Reconstruction with Deep Learning}",
+ booktitle      = "{Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017)}",
+ year           = "2017",
+ url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_28.pdf}"
+}
+
+% December 8, 2017
+@conference{Henrion:DLPS2017,
+ author         = "Isaac Henrion and Kyle Cranmer and Joan Bruna and Kyunghyun Cho
+ and Johann Brehmer and Gilles Louppe and Gaspar Rochette",
+ title          = "{Neural Message Passing for Jet Physics}",
+ booktitle      = "{Proceedings of the Deep Learning for Physical Sciences Workshop at NIPS (2017)}",
+ year           = "2017",
+ url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_29.pdf}"
+}
+
 % November 7, 2017
 @article{Cheng:2017rdo,
  author         = "Cheng, Taoli",

--- a/tex/HEPML.bib
+++ b/tex/HEPML.bib
@@ -1,5 +1,16 @@
 # HEPML Papers
 
+% November 7, 2017
+@article{Cheng:2017rdo,
+ author         = "Cheng, Taoli",
+ title          = "{Recursive Neural Networks in Quark/Gluon Tagging}",
+ year           = "2017",
+ eprint         = "1711.02633",
+ archivePrefix  = "arXiv",
+ primaryClass   = "hep-ph",
+ SLACcitation   = "%%CITATION = ARXIV:1711.02633;%%"
+}
+
 % September 17, 2017
 @article{Frate:2017mai,
  author         = "Frate, Meghan and Cranmer, Kyle and Kalia, Saarik and

--- a/tex/HEPML.tex
+++ b/tex/HEPML.tex
@@ -25,6 +25,15 @@
 \begin{document}
 
 \begin{itemize}
+ \item~\cite{Estrade:DLPS2017}
+ \item~\cite{Weitekamp:DLPS2017}
+ \item~\cite{Hertel:DLPS2017}
+ \item~\cite{Stoye:DLPS2017}
+ \item~\cite{Hooberman:DLPS2017}
+ \item~\cite{Paganini:DLPS2017}
+ \item~\cite{Oliveira:DLPS2017}
+ \item~\cite{Farrell:DLPS2017}
+ \item~\cite{Henrion:DLPS2017}
  \item~\cite{Cheng:2017rdo}
  \item~\cite{Frate:2017mai}
  \item~\cite{Metodiev:2017vrx}

--- a/tex/HEPML.tex
+++ b/tex/HEPML.tex
@@ -25,6 +25,7 @@
 \begin{document}
 
 \begin{itemize}
+ \item~\cite{Cheng:2017rdo}
  \item~\cite{Frate:2017mai}
  \item~\cite{Metodiev:2017vrx}
  \item~\cite{Bendavid:2017zhk}


### PR DESCRIPTION
Resolves #21

Add the papers suggested in Issue #21 

- Add "Recursive Neural Networks in Quark/Gluon Tagging"