### PR TITLE
Add paper on latent state reference entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Listing of useful (mostly) public learning resources for machine learning applic
 
 > A `.bib` file for all papers listed is [available in the `tex` directory](https://github.com/iml-wg/HEP-ML-Resources/blob/master/tex/HEPML.bib).
 
-- M. Stoye, J. Brehmer, L. Gilles, J. Paez, and K. Cranmer "[Likelihood-free inference with an improved cross-entropy estimator](https://inspirehep.net/record/1684960)," arXiv:1808.00973 [stat.ML]. (August 2, 2018)
+- M. Stoye, J. Brehmer, L. Gilles, J. Paez, and K. Cranmer, "[Likelihood-free inference with an improved cross-entropy estimator](https://inspirehep.net/record/1684960)," arXiv:1808.00973 [stat.ML]. (August 2, 2018)
 
 - D. Bourgeois, C. Fitzpatrick, and S. Stahl, "[Using holistic event information in the Trigger](https://inspirehep.net/record/1684792)," arXiv:1808.00711 [physics.ins-det]. (August 2, 2018)
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Listing of useful (mostly) public learning resources for machine learning applic
 
 > A `.bib` file for all papers listed is [available in the `tex` directory](https://github.com/iml-wg/HEP-ML-Resources/blob/master/tex/HEPML.bib).
 
+- M. Stoye, J. Brehmer, L. Gilles, J. Paez, and K. Cranmer "[Likelihood-free inference with an improved cross-entropy estimator](https://inspirehep.net/record/1684960)," arXiv:1808.00973 [stat.ML]. (August 2, 2018)
+
 - D. Bourgeois, C. Fitzpatrick, and S. Stahl, "[Using holistic event information in the Trigger](https://inspirehep.net/record/1684792)," arXiv:1808.00711 [physics.ins-det]. (August 2, 2018)
 
 - M. Andrews, M. Paulini, S. Gleyzer, and B. Poczos, "[End-to-End Physics Event

--- a/tex/HEPML.bib
+++ b/tex/HEPML.bib
@@ -1,6 +1,19 @@
 # HEPML Papers
 
 % August 2, 2018
+@article{Stoye:2018ovl,
+      author         = "Stoye, Markus and Brehmer, Johann and Louppe, Gilles and
+                        Pavez, Juan and Cranmer, Kyle",
+      title          = "{Likelihood-free inference with an improved cross-entropy
+                        estimator}",
+      year           = "2018",
+      eprint         = "1808.00973",
+      archivePrefix  = "arXiv",
+      primaryClass   = "stat.ML",
+      SLACcitation   = "%%CITATION = ARXIV:1808.00973;%%"
+}
+
+% August 2, 2018
 @article{Bourgeois:2018nvk,
       author         = "Bourgeois, Dylan and Fitzpatrick, Conor and Stahl,
                         Sascha",

--- a/tex/HEPML.tex
+++ b/tex/HEPML.tex
@@ -25,6 +25,7 @@
 \begin{document}
 
 \begin{itemize}
+ \item~\cite{Stoye:2018ovl}
  \item~\cite{Bourgeois:2018nvk}
  \item~\cite{Andrews:2018nwy}
  \item~\cite{Lin:2018cin}


### PR DESCRIPTION
M. Stoye, J. Brehmer, L. Gilles, J. Paez, and K. Cranmer, "[Likelihood-free inference with an improved cross-entropy estimator](https://inspirehep.net/record/1684960)," arXiv:1808.00973 [stat.ML]. (August 2, 2018)