### PR TITLE
Add CMS Machine Learning Workshop 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ from mixed samples in high energy physics](https://inspirehep.net/record/1615464
 
 ### Past
 
+- [CMS Machine Learning Workshop (2018)](https://indico.cern.ch/event/730677/) (July 2-4, 2018) ![CMS only](https://img.shields.io/badge/restricted-CMS-red.svg)
 - [2nd IML Machine Learning Workshop (2018)](https://indico.cern.ch/event/668017/) (April 9-12, 2018)
 - [Machine Learning for Phenomenology (2018)](https://conference.ippp.dur.ac.uk/event/660/) (April 3-6, 2018)
 - [4th International Connecting The Dots Workshop (2018)](https://indico.cern.ch/event/658267/) (March 20-22, 2018)


### PR DESCRIPTION
Thanks for compiling the list -- it's very useful! I would like to add the CMS-only workshop to the list.