### PR TITLE
Add 5th Machine Learning in HEP Summer School

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Listing of useful (mostly) public learning resources for machine learning applic
 
 ##### Upcoming:
 
-- TBA
+- [5th Machine Learning in High Energy Physics Summer School 2019](https://indico.cern.ch/event/768915/) (July 1-10, 2019)
+   - Associated [Yandex School of Data Analysis](https://github.com/yandexdataschool)
 
 ##### Past:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Listing of useful (mostly) public learning resources for machine learning applic
 ##### Upcoming:
 
 - [5th Machine Learning in High Energy Physics Summer School 2019](https://indico.cern.ch/event/768915/) (July 1-10, 2019)
-   - Associated [Yandex School of Data Analysis](https://github.com/yandexdataschool)
 
 ##### Past:
 


### PR DESCRIPTION
Add the [5th Machine Learning in High Energy Physics Summer School 2019](https://indico.cern.ch/event/768915/) to upcoming HEPML summer schools.