### PR TITLE
Add ICML 2019 Physics for DL workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,12 @@ A listing of papers of applications of machine learning to high energy physics c
 
 ### Upcoming
 
-- [3rd IML Machine Learning Workshop (2019)](https://indico.cern.ch/event/766872/) (April 15-18, 2019)
-- [Accelerating the Search for Dark Matter with Machine Learning (2019)](http://indico.ictp.it/event/8674/) (April 8-12, 2019)
+- [Theoretical Physics for Deep Learning at ICML 2019](https://sites.google.com/view/icml2019phys4dl) (June 14, 2019)
 
 ### Past
 
+- [3rd IML Machine Learning Workshop (2019)](https://indico.cern.ch/event/766872/) (April 15-18, 2019)
+- [Accelerating the Search for Dark Matter with Machine Learning (2019)](http://indico.ictp.it/event/8674/) (April 8-12, 2019)
 - [5th Connecting The Dots / Intelligent Trackers (2019)](https://indico.cern.ch/event/742793/) (April 2-5, 2019)
 - [19th International Workshop on Advanced Computing and Analysis Techniques in Physics Research (ACAT 2019)](https://indico.cern.ch/event/708041/) (March 11-15, 2019)
 - [Machine Learning for Jet Physics (2018)](https://indico.cern.ch/event/745718/) (November 14-16, 2018)


### PR DESCRIPTION
# Description

Add [Theoretical Physics for Deep Learning at ICML 2019](https://sites.google.com/view/icml2019phys4dl)

Also move past workshops to the "past" section