### PR TITLE
Add impact of deep learning on HEP paper

### DIFF
--- a/papers.md
+++ b/papers.md
@@ -4,6 +4,8 @@
 
 > A `.bib` file for all papers listed is [available in the `tex` directory](https://github.com/iml-wg/HEP-ML-Resources/blob/master/tex/HEPML.bib).
 
+- G. C. Strong, "[On the impact of modern deep-learning techniques to the performance and time-requirements of classification models in experimental high-energy physics](https://inspirehep.net/record/1778508)," arXiv:2002.01427 [physics.data-an]. (February 3, 2020)
+
 - A. Andreassen, P. T. Komiske, E. M. Metodiev, B. Nachman, and J. Thaler, "[OmniFold: A Method to Simultaneously Unfold All Observables](https://inspirehep.net/record/1766424)," arXiv:1911.09107 [hep-ph]. (November 20, 2019)
 
 - B. Nachman and C. Shimmin, "[AI Safety for High Energy Physics](https://inspirehep.net/record/1759867)," arXiv:1910.08606 [hep-ph]. (October 18, 2019)

--- a/tex/HEPML.bib
+++ b/tex/HEPML.bib
@@ -1,5 +1,18 @@
 # HEPML Papers
 
+% February 3, 2020
+@article{Strong:2020mge,
+      author         = "Strong, Giles Chatham",
+      title          = "{On the impact of modern deep-learning techniques to the
+                        performance and time-requirements of classification models
+                        in experimental high-energy physics}",
+      year           = "2020",
+      eprint         = "2002.01427",
+      archivePrefix  = "arXiv",
+      primaryClass   = "physics.data-an",
+      SLACcitation   = "%%CITATION = ARXIV:2002.01427;%%"
+}
+
 % November 20, 2019
 @article{Andreassen:2019cjw,
       author         = "Andreassen, Anders and Komiske, Patrick T. and Metodiev,

--- a/tex/HEPML.tex
+++ b/tex/HEPML.tex
@@ -25,6 +25,7 @@
 \begin{document}
 
 \begin{itemize}
+ \item~\cite{Strong:2020mge}
  \item~\cite{Andreassen:2019cjw}
  \item~\cite{Nachman:2019yfl}
  \item~\cite{Borisyak:2019vbz}


### PR DESCRIPTION
Add [On the impact of modern deep-learning techniques to the performance and time-requirements of classification models in experimental high-energy physics](https://inspirehep.net/record/1778508) by @GilesStrong