### PR TITLE
Add MicroBooNE DNN paper

### DIFF
--- a/papers.md
+++ b/papers.md
@@ -16,6 +16,8 @@
 
 - K. Datta, A. Larkoski, and B. Nachman, "[Automating the Construction of Jet Observables with Machine Learning](https://inspirehep.net/record/1720832)," arXiv:1902.07180 [hep-ph]. (February 19, 2019)
 
+- MicroBooNE Collaboration, "[Deep neural network for pixel-level electromagnetic particle identification in the MicroBooNE liquid argon time projection chamber](https://inspirehep.net/record/1689384)," Phys. Rev. D99 (2019) no. 9, 092001, arXiv:1808.07269 [hep-ex]. (August 22, 2018)
+
 - M. Stoye, J. Brehmer, L. Gilles, J. Paez, and K. Cranmer, "[Likelihood-free inference with an improved cross-entropy estimator](https://inspirehep.net/record/1684960)," arXiv:1808.00973 [stat.ML]. (August 2, 2018)
 
 - D. Bourgeois, C. Fitzpatrick, and S. Stahl, "[Using holistic event information in the Trigger](https://inspirehep.net/record/1684792)," arXiv:1808.00711 [physics.ins-det]. (August 2, 2018)

--- a/tex/HEPML.bib
+++ b/tex/HEPML.bib
@@ -77,6 +77,26 @@
       SLACcitation   = "%%CITATION = ARXIV:1902.07180;%%"
 }
 
+% August 22, 2018
+@article{Adams:2018bvi,
+      author         = "Adams, C. and others",
+      title          = "{Deep neural network for pixel-level electromagnetic
+                        particle identification in the MicroBooNE liquid argon
+                        time projection chamber}",
+      collaboration  = "MicroBooNE",
+      journal        = "Phys. Rev.",
+      volume         = "D99",
+      year           = "2019",
+      number         = "9",
+      pages          = "092001",
+      doi            = "10.1103/PhysRevD.99.092001",
+      eprint         = "1808.07269",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ex",
+      reportNumber   = "FERMILAB-PUB-18-231-ND",
+      SLACcitation   = "%%CITATION = ARXIV:1808.07269;%%"
+}
+
 % August 2, 2018
 @article{Stoye:2018ovl,
       author         = "Stoye, Markus and Brehmer, Johann and Louppe, Gilles and

--- a/tex/HEPML.tex
+++ b/tex/HEPML.tex
@@ -31,6 +31,7 @@
  \item~\cite{Borisyak:2019vbz}
  \item~\cite{DiSipio:2019imz}
  \item~\cite{Datta:2019}
+ \item~\cite{Adams:2018bvi}
  \item~\cite{Stoye:2018ovl}
  \item~\cite{Bourgeois:2018nvk}
  \item~\cite{Andrews:2018nwy}


### PR DESCRIPTION
Add [Deep neural network for pixel-level electromagnetic particle identification in the MicroBooNE liquid argon time projection chamber](https://inspirehep.net/record/1689384) by the MicroBooNE collaboration.