### PR TITLE
Add ML learned likelihood ratio paper

### DIFF
--- a/papers.md
+++ b/papers.md
@@ -4,6 +4,8 @@
 
 > A `.bib` file for all papers listed is [available in the `tex` directory](https://github.com/iml-wg/HEP-ML-Resources/blob/master/tex/HEPML.bib).
 
+- J. Hollingsworth and D. Whiteson, "[Resonance Searches with Machine Learned Likelihood Ratios](https://inspirehep.net/record/1779859)," arXiv:2002.04699 [hep-ph]. (February 11, 2020)
+
 - G. C. Strong, "[On the impact of modern deep-learning techniques to the performance and time-requirements of classification models in experimental high-energy physics](https://inspirehep.net/record/1778508)," arXiv:2002.01427 [physics.data-an]. (February 3, 2020)
 
 - A. Andreassen, P. T. Komiske, E. M. Metodiev, B. Nachman, and J. Thaler, "[OmniFold: A Method to Simultaneously Unfold All Observables](https://inspirehep.net/record/1766424)," arXiv:1911.09107 [hep-ph]. (November 20, 2019)

--- a/tex/HEPML.bib
+++ b/tex/HEPML.bib
@@ -1,5 +1,17 @@
 # HEPML Papers
 
+% February 11, 2020
+@article{Hollingsworth:2020kjg,
+      author         = "Hollingsworth, Jacob and Whiteson, Daniel",
+      title          = "{Resonance Searches with Machine Learned Likelihood
+                        Ratios}",
+      year           = "2020",
+      eprint         = "2002.04699",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ph",
+      SLACcitation   = "%%CITATION = ARXIV:2002.04699;%%"
+}
+
 % February 3, 2020
 @article{Strong:2020mge,
       author         = "Strong, Giles Chatham",

--- a/tex/HEPML.tex
+++ b/tex/HEPML.tex
@@ -25,6 +25,7 @@
 \begin{document}
 
 \begin{itemize}
+ \item~\cite{Hollingsworth:2020kjg}
  \item~\cite{Strong:2020mge}
  \item~\cite{Andreassen:2019cjw}
  \item~\cite{Nachman:2019yfl}


### PR DESCRIPTION
Add [Resonance Searches with Machine Learned Likelihood Ratios](https://inspirehep.net/record/1779859) by Jacob Hollingsworth and Daniel Whiteson.