### PR TITLE
Add transferability of deep learning models paper

### DIFF
--- a/papers.md
+++ b/papers.md
@@ -12,6 +12,8 @@ theory](https://inspirehep.net/record/1785309)," arXiv:2003.06413 [hep-lat]. (Ma
 
 - G. C. Strong, "[On the impact of modern deep-learning techniques to the performance and time-requirements of classification models in experimental high-energy physics](https://inspirehep.net/record/1778508)," arXiv:2002.01427 [physics.data-an]. (February 3, 2020)
 
+- M. Romão Crispim, N. Castro, R. Pedro, and T. Vale, "[Transferability of Deep Learning Models in Searches for New Physics at Colliders](https://inspirehep.net/literature/1769198)," Phys. Rev. D 101 (2020) no. 3, 035042, arXiv:1912.04220 [hep-ph]. (December 9, 2019)
+
 - A. Andreassen, P. T. Komiske, E. M. Metodiev, B. Nachman, and J. Thaler, "[OmniFold: A Method to Simultaneously Unfold All Observables](https://inspirehep.net/record/1766424)," arXiv:1911.09107 [hep-ph]. (November 20, 2019)
 
 - B. Nachman and C. Shimmin, "[AI Safety for High Energy Physics](https://inspirehep.net/record/1759867)," arXiv:1910.08606 [hep-ph]. (October 18, 2019)

--- a/tex/HEPML.bib
+++ b/tex/HEPML.bib
@@ -42,6 +42,21 @@
       SLACcitation   = "%%CITATION = ARXIV:2002.01427;%%"
 }
 
+% December 9, 2019
+@article{Romao:2019dvs,
+    author = "Romão Crispim, M. and Castro, N.F. and Pedro, R. and Vale, T.",
+    archivePrefix = "arXiv",
+    doi = "10.1103/PhysRevD.101.035042",
+    eprint = "1912.04220",
+    journal = "Phys.\ Rev.\ D",
+    number = "3",
+    pages = "035042",
+    primaryClass = "hep-ph",
+    title = "{Transferability of Deep Learning Models in Searches for New Physics at Colliders}",
+    volume = "101",
+    year = "2020"
+}
+
 % November 20, 2019
 @article{Andreassen:2019cjw,
       author         = "Andreassen, Anders and Komiske, Patrick T. and Metodiev,

--- a/tex/HEPML.tex
+++ b/tex/HEPML.tex
@@ -28,6 +28,7 @@
  \item~\cite{Kanwar:2003.06413}
  \item~\cite{Hollingsworth:2020kjg}
  \item~\cite{Strong:2020mge}
+ \item~\cite{Romao:2019dvs}
  \item~\cite{Andreassen:2019cjw}
  \item~\cite{Nachman:2019yfl}
  \item~\cite{Borisyak:2019vbz}


### PR DESCRIPTION
Resolves #71 

Add [Transferability of Deep Learning Models in Searches for New Physics at Colliders](https://inspirehep.net/literature/1769198) by M. Romão Crispim, @nfcastro, R. Pedro, and T. Vale.